### PR TITLE
[1/2] OmniJaws: refactor weather data

### DIFF
--- a/src/org/omnirom/omnijaws/SystemReceiver.java
+++ b/src/org/omnirom/omnijaws/SystemReceiver.java
@@ -25,7 +25,7 @@ import android.util.Log;
 
 public class SystemReceiver extends BroadcastReceiver {
     private static final String TAG = "WeatherService:SystemReceiver";
-    private static final boolean DEBUG = true;
+    private static final boolean DEBUG = false;
 
     @Override
     public void onReceive(final Context context, Intent intent) {

--- a/src/org/omnirom/omnijaws/WeatherContentProvider.java
+++ b/src/org/omnirom/omnijaws/WeatherContentProvider.java
@@ -40,7 +40,8 @@ public class WeatherContentProvider extends ContentProvider {
     private static final String COLUMN_CURRENT_CONDITION = "condition";
     private static final String COLUMN_CURRENT_TEMPERATURE = "temperature";
     private static final String COLUMN_CURRENT_HUMIDITY = "humidity";
-    private static final String COLUMN_CURRENT_WIND = "wind";
+    private static final String COLUMN_CURRENT_WIND_SPEED = "wind_speed";
+    private static final String COLUMN_CURRENT_WIND_DIRECTION = "wind_direction";
     private static final String COLUMN_CURRENT_TIME_STAMP = "time_stamp";
     private static final String COLUMN_CURRENT_CONDITION_CODE = "condition_code";
 
@@ -62,7 +63,8 @@ public class WeatherContentProvider extends ContentProvider {
             COLUMN_CURRENT_CONDITION,
             COLUMN_CURRENT_TEMPERATURE,
             COLUMN_CURRENT_HUMIDITY,
-            COLUMN_CURRENT_WIND,
+            COLUMN_CURRENT_WIND_SPEED,
+            COLUMN_CURRENT_WIND_DIRECTION,
             COLUMN_CURRENT_TIME_STAMP,
             COLUMN_CURRENT_CONDITION_CODE,
             COLUMN_FORECAST_LOW,
@@ -116,7 +118,7 @@ public class WeatherContentProvider extends ContentProvider {
                     .add(COLUMN_ENABLED, Config.isEnabled(mContext) ? 1 : 0)
                     .add(COLUMN_PROVIDER, Config.getProviderId(mContext))
                     .add(COLUMN_INTERVAL, Config.getUpdateInterval(mContext))
-                    .add(COLUMN_UNITS, Config.isMetric(mContext))
+                    .add(COLUMN_UNITS, Config.isMetric(mContext) ? 0 : 1)
                     .add(COLUMN_LOCATION, Config.isCustomLocation(mContext) ? Config.getLocationName(mContext) : "");
 
             return result;
@@ -129,9 +131,9 @@ public class WeatherContentProvider extends ContentProvider {
                         .add(COLUMN_CURRENT_CITY_ID, weather.getId())
                         .add(COLUMN_CURRENT_CONDITION, weather.getCondition())
                         .add(COLUMN_CURRENT_HUMIDITY, weather.getFormattedHumidity())
-                        .add(COLUMN_CURRENT_WIND, weather.getFormattedWindSpeed()
-                                + " " + weather.getWindDirection())
-                        .add(COLUMN_CURRENT_TEMPERATURE, weather.getFormattedTemperature())
+                        .add(COLUMN_CURRENT_WIND_SPEED, weather.getWindSpeed())
+                        .add(COLUMN_CURRENT_WIND_DIRECTION, weather.getWindDirection())
+                        .add(COLUMN_CURRENT_TEMPERATURE, weather.getTemperature())
                         .add(COLUMN_CURRENT_TIME_STAMP, weather.getTimestamp().toString())
                         .add(COLUMN_CURRENT_CONDITION_CODE, weather.getConditionCode());
 
@@ -139,8 +141,8 @@ public class WeatherContentProvider extends ContentProvider {
                 for (DayForecast day : weather.getForecasts()) {
                     result.newRow()
                             .add(COLUMN_FORECAST_CONDITION, day.getCondition(mContext))
-                            .add(COLUMN_FORECAST_LOW, day.getFormattedLow())
-                            .add(COLUMN_FORECAST_HIGH, day.getFormattedHigh())
+                            .add(COLUMN_FORECAST_LOW, day.getLow())
+                            .add(COLUMN_FORECAST_HIGH, day.getHigh())
                             .add(COLUMN_FORECAST_CONDITION_CODE, day.getConditionCode())
                             .add(COLUMN_FORECAST_DATE, day.date);
                 }

--- a/src/org/omnirom/omnijaws/WeatherInfo.java
+++ b/src/org/omnirom/omnijaws/WeatherInfo.java
@@ -83,12 +83,12 @@ public class WeatherInfo {
             this.date = date;
         }
 
-        public String getFormattedLow() {
-            return getFormattedValue(low, "\u00b0" + (metric ? "C" : "F"));
+        public float getLow() {
+            return low;
         }
 
-        public String getFormattedHigh() {
-            return getFormattedValue(high, "\u00b0"  + (metric ? "C" : "F"));
+        public float getHigh() {
+            return high;
         }
 
         public String getCondition(Context context) {
@@ -144,35 +144,38 @@ public class WeatherInfo {
         return formatted + unit;
     }
 
-    public String getFormattedLow() {
-        return forecasts.get(0).getFormattedLow();
-    }
-
-    public String getFormattedHigh() {
-        return forecasts.get(0).getFormattedHigh();
-    }
-
     public String getFormattedHumidity() {
         return getFormattedValue(humidity, "%");
     }
 
-    public String getFormattedWindSpeed() {
+    public float getWindSpeed() {
         if (wind < 0) {
-            return "-1";
+            return 0;
+        }
+        return wind;
+    }
+
+    private String getFormattedWindSpeed() {
+        if (wind < 0) {
+            return "0";
         }
         return getFormattedValue(wind, metric?"km/h":"m/h");
     }
 
-    public String getWindDirection() {
-        return String.valueOf(windDirection) + "deg";
+    public int getWindDirection() {
+        return windDirection;
     }
 
     public ArrayList<DayForecast> getForecasts() {
         return forecasts;
     }
 
-    public String getFormattedTemperature() {
-        return getFormattedValue(temperature, "\u00b0" + (metric ? "C" : "F"));
+    public float getTemperature() {
+        return temperature;
+    }
+
+    private String getTemperatureUnit() {
+        return "\u00b0" + (metric ? "C" : "F");
     }
 
     @Override
@@ -189,11 +192,7 @@ public class WeatherInfo {
         builder.append("(");
         builder.append(conditionCode);
         builder.append("), temperature ");
-        builder.append(getFormattedTemperature());
-        builder.append(", low ");
-        builder.append(getFormattedLow());
-        builder.append(", high ");
-        builder.append(getFormattedHigh());
+        builder.append(getFormattedValue(getTemperature(), getTemperatureUnit()));
         builder.append(", humidity ");
         builder.append(getFormattedHumidity());
         builder.append(", wind ");
@@ -210,8 +209,8 @@ public class WeatherInfo {
             }
             builder.append(" day ").append(i + 1).append(":");
             builder.append(d.date);
-            builder.append(" high ").append(d.getFormattedHigh());
-            builder.append(", low ").append(d.getFormattedLow());
+            builder.append(" high ").append(getFormattedValue(d.getHigh(), getTemperatureUnit()));
+            builder.append(", low ").append(getFormattedValue(d.getLow(), getTemperatureUnit()));
             builder.append(", ").append(d.condition);
             builder.append("(").append(d.conditionCode).append(")");
         }


### PR DESCRIPTION
dont encode unit based strings in the WeatherInfo
but let the client decide about it.

provider only delivers the raw data

Change-Id: I8ec59ff1a2076a34c8b80e8c629242bdfee37d24